### PR TITLE
Fix missing config entries in jinja template

### DIFF
--- a/docs/module_docs/templates/module.rst.jinja
+++ b/docs/module_docs/templates/module.rst.jinja
@@ -8,32 +8,45 @@ Description
 ###########
 {{ manifest.description}}
 
-Implemented interfaces
-######################
+{% if manifest.config %}
+Module Configuration
+####################
+{% for config_entry in manifest.config -%}
+
+| **{{ config_entry }}**:*{{ manifest.config[config_entry].type}}*
+{% if manifest.config[config_entry].default -%}
+| *default:    {{ manifest.config[config_entry].default }}*
+{%- endif %}
+| {{ manifest.config[config_entry].description }}
+
+{% endfor -%}
+{% endif %}
+Provides
+########
 {% for implementation in manifest.provides -%}
 
 | **{{ implementation }}**:*{{ manifest.provides[implementation].interface}}*
 | {{ manifest.provides[implementation].description}}
-
+{% if manifest.provides[implementation].config -%}
+| config:
+{% for config_entry in manifest.provides[implementation].config -%}
+|  **{{ config_entry }}**:*{{ manifest.provides[implementation].config[config_entry].type}}*
+{% if manifest.provides[implementation].config[config_entry].default -%}
+|  *default:    {{ manifest.provides[implementation].config[config_entry].default }}*
+{% endif -%}
+|  {{ manifest.provides[implementation].config[config_entry].description }}
 {% endfor -%}
-
-Configuration
-#############
-{% for config_entry in manifest.config -%}
-
-| **{{ config_entry }}**:*{{ manifest.config[config_entry].type}}*
-| *default:    {{ manifest.config[config_entry].default }}*
-| {{ manifest.config[config_entry].description }}
-
+{% endif -%}
+{###}
 {% endfor -%}
-
+{% if manifest.requires %}
 Requirements
 ############
 {% for req in manifest.requires -%}
 
 | **{{ req }}**:*{{manifest.requires[req].interface}}*
 {% endfor -%}
-
+{% endif %}
 {###}
 Metadata
 ########
@@ -45,3 +58,4 @@ Authors
 License
 *******
 {{ manifest.metadata.license }}
+{###}


### PR DESCRIPTION
- Rename "provides" section
- Rename "config" to "module config"
- Add implementation config

Signed-off-by: Andreas Heinrich <andreas.heinrich@rwth-aachen.de>