### PR TITLE
Introduce new introduction and split quick start guide into separated files

### DIFF
--- a/docs/general/detail_module_concept.rst
+++ b/docs/general/detail_module_concept.rst
@@ -1,0 +1,154 @@
+.. detail_module_concept:
+
+######################
+EVerest Module Concept
+######################
+
+What parts does a module in EVerest consist of?
+
+- Interface definition
+- Types definition
+- Module implementation
+
+Let's have a quick look to those parts in the following sections.
+
+.. important:: 
+
+  This documentation has been written during a work in progress which would change interface and types definitions from JSON to YAML. This will be reflected in short here.
+
+Interfaces
+==========
+
+An interface generally describes a specific object in the EVerest world. Those objects can be device types, protocol standards, authentication instances and so on.
+
+Everything that you will want to integrate into EVerest as a module will need to have an interface definition.
+
+A short view on an interface describing a powermeter:
+
+.. code-block:: json
+
+  {
+    "description": "This interface defines a generic powermeter for 5 wire TN networks.",
+    "cmds": {
+        "get_signed_meter_value": {
+            "description": "Returns a signed meter value with the given auth token",
+            "arguments": {
+                "auth_token": {
+                    "description": "Auth token",
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 20
+                }
+            },
+            "result": {
+                "description": "Signed meter value",
+                "type": "string"
+            }
+        }
+    },
+    "vars": {
+        "powermeter": {
+            "description": "Measured dataset",
+            "type": "object",
+            "$ref": "/powermeter#/Powermeter"
+        }
+    }
+  }
+
+Let's walk in short through the keys:
+
+The description simply tells you in short, which type of object the interface describes.
+
+Interfaces have commands (cmds) which can be called from the outside synchronously. Those commands can take arguments which can be limited regarding its values. As an example, see the `minLength` and `maxLength` keys in the code above.
+
+Besides that, variables (vars) can be consumed by other modules in an asynchronous way. Variables are published by the interface implementing object. The powermeter example above does that with the measured dataset. Example: If module A implements this interface and module B connects to it, module B will get the measured dataset as often as module A publishes that data. 
+
+Both cmds and vars can be defined as simple data types (string, bool etc) or as object type - in case you want to have a more sophisticated structure than a simple type.
+
+Those object types have to be defined. In EVerest, we do this as a Type Definition.
+
+Types
+=====
+
+A short view on how the powermeter type could look like:
+
+.. code-block:: json
+
+  {
+    "description": "Powermeter types",
+    "types": {
+        "Powermeter": {
+            "description": "Measured dataset",
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "timestamp",
+                "energy_Wh_import"
+            ],
+            "properties": {
+                "timestamp": {
+                    "description": "Timestamp of measurement",
+                    "type": "number"
+                },
+                "meter_id": {
+                    "description": "A (user defined) meter if (e.g. id printed on the case)",
+                    "type": "string"
+                }
+            }
+        }
+    }
+  }
+
+This type has been used and referenced in the powermeter interface.
+
+You can understand the interface description as the description of a general powermeter device and the powermeter type as a data object that is used by a powermeter device to exchange measurement information.
+
+The type definition tells EVerest which properties this type has. This is the data structure of the type. The JSON key *required* defines what is needed.
+
+With this, we have now interfaces and types set. Let's have a look at the module:
+
+Modules
+=======
+
+Each module resides in the `modules <https://github.com/EVerest/everest-core/tree/main/modules>`_ directory as a subdirectory.
+
+The modules consist of one or more interfaces.
+
+Each module is defined by its `manifest.json` file:
+
++----------------+-----------------------------------------------+------------------------------------------------------------------+
+|    JSON KEY    |    description                                | value type                                                       |
++================+===============================================+==================================================================+
+| *description*  | useful description of what the module does    | string                                                           |
++----------------+-----------------------------------------------+------------------------------------------------------------------+
+| *provides*     | interfaces provided by the module,            | {<interface id1>: {interface, description, [config]},            |
+|                | can be required by other modules              | <interface id2>: {interface, description, [config]}, ... }       |
++----------------+-----------------------------------------------+------------------------------------------------------------------+
+| *requires*     | interfaces required by the module,            | {<interface id1>: {interface}, <interface id2>: {interface},...} |
+|                | needs to be provided by other module(s)       |                                                                  |
++----------------+-----------------------------------------------+------------------------------------------------------------------+
+| *metadata*     | metadata                                      | {license: <string>, authors: <array>}                            |
++----------------+-----------------------------------------------+------------------------------------------------------------------+
+
+An example module can be found `here <https://github.com/EVerest/everest-core/tree/main/modules/Example>`_.
+
+So, the *manifest.json* contains information about which interfaces are implemented by the module including the parameters needed to configure those interfaces. Also, it defines which interface implementations are needed to be implemented by other modules which are connecting to this module.
+
+Further files can be found in the *module* directory:
+- .cpp and .hpp code files for the implementations
+- CMakeList.txt file to define needed libraries for the cmake run
+- Implementations of interfaces in separate code files
+
+Connecting The Modules
+======================
+
+Now as we have learnt about the basic concept of modules, we will need to see how to glue everything together.
+
+When setting up EVerest as shown in the Quick Start Guide, you will receive a first example of a module network. This is delivered as a first example by using the EDM tool.
+
+You can find some examples of module connection definitions in the `everest-core` repository in directory `config`. Have a look at the YAML files to get an idea of how those module connections are defined there.
+
+Where To Go Next
+================
+
+If you came here via the Quick Start Guide, here is your way back to action: `Quick Start Guide to setup a module <quick_start_guide.html#module-setup>`_.

--- a/docs/general/detail_pre_setup.rst
+++ b/docs/general/detail_pre_setup.rst
@@ -1,0 +1,50 @@
+.. detail_pre_setup:
+
+####################################
+Prepare Your Development Environment
+####################################
+
+To get EVerest running properly, you will mainly need the following packages:
+
+* Python (greater than 3.6)
+* Jinja2
+* PyYAML
+* Compiler:
+
+  * GCC 9 (lower versions could work with some tweaking but are not recommended)
+  * Clang (starting with version 12) has been used with EVerest but is not officially supported.
+
+A complete list of libraries to be installed is given by the following best practices which setup a development environment on a number of operating systems.
+
+Ubuntu
+======
+
+Use `apt` to get your needed libraries installed:
+
+.. code-block:: bash
+
+  sudo apt update
+  sudo apt install -y python3-pip git rsync wget cmake doxygen graphviz build-essential clang-tidy cppcheck maven openjdk-11-jdk npm docker docker-compose libboost-all-dev nodejs libssl-dev libsqlite3-dev clang-format curl rfkill
+
+Please make sure to have `nodejs` installed with minimum version 10.20 for `node_api` version 6+. For updating to a supported version, please follow the install procedure here: `<https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions>`_.
+
+OpenSUSE
+========
+Use `zypper` to get your needed libraries installed:
+
+.. code-block:: bash
+
+  zypper update && zypper install -y sudo shadow
+  zypper install -y --type pattern devel_basis
+  zypper install -y git rsync wget cmake doxygen graphviz clang-tools cppcheck boost-devel libboost_filesystem-devel libboost_log-devel libboost_program_options-devel libboost_system-devel libboost_thread-devel maven java-11-openjdk java-11-openjdk-devel nodejs nodejs-devel npm python3-pip gcc-c++ libopenssl-devel sqlite3-devel
+
+Fedora
+======
+Tested with Fedora 36. Here is how to get your needed libraries with `dnf`.
+
+.. code-block:: bash
+
+  sudo dnf update
+  sudo dnf install make automake gcc gcc-c++ kernel-devel python3-pip git rsync wget cmake doxygen graphviz clang-tools-extra cppcheck maven java-11-openjdk java-11-openjdk-devel boost-devel nodejs nodejs-devel npm openssl-devel libsqlite3x-devel curl rfkill
+
+Now, it's time to continue with the `Quick Start Guide to install EVerest <quick_start_guide.html#download-and-install>`_.

--- a/docs/general/framework.rst
+++ b/docs/general/framework.rst
@@ -2,36 +2,70 @@
 
 EVerest framework
 #################
+You can think of EVerest as an operating system for EV chargers with implementations of communication protocols, software modules for representations of hardware devices (chargers, cars, …) and tools for simulating the charging process.
 
-See our Quick Start Guide for a fast overview and first steps to create new modules: :ref:`general/quick_start_guide:a real quick guide to everest`
+It's a full stack environment for EV charging.
 
-EVerest uses the principle of loose coupling of modules that allow configuration during runtime.
+*********************
+A Visual Introduction
+*********************
 
-Modules
--------
+A first very high level overview of the framework can be seen here:
 
-`Modules <https://github.com/EVerest/everest-core/tree/main/modules>`_ consist of one or more interfaces.
-Each module is defined by its `manifest.json` file:
+.. image:: img/quick-start-high-level-1.png
 
-+----------------+-----------------------------------------------+------------------------------------------------------------------+
-|    JSON KEY    |    description                                | value type                                                       |
-+================+===============================================+==================================================================+
-| *description*  | useful description of what the module does    | string                                                           |
-+----------------+-----------------------------------------------+------------------------------------------------------------------+
-| *provides*     | interfaces provided by the module,            | {<interface id1>: {interface, description, [config]},            |
-|                | can be required by other modules              | <interface id2>: {interface, description, [config]}, ... }       |
-+----------------+-----------------------------------------------+------------------------------------------------------------------+
-| *requires*     | interfaces required by the module,            | {<interface id1>: {interface}, <interface id2>: {interface},...} |
-|                | needs to be provided by other module(s)       |                                                                  |
-+----------------+-----------------------------------------------+------------------------------------------------------------------+
-| *metadata*     | metadata                                      | {license: <string>, authors: <array>}                            |
-+----------------+-----------------------------------------------+------------------------------------------------------------------+
+The EVerest framework helps with building your dedicated development scenario with all needed modules for your specific developer's use case. The modules are connected by using the principle of loose coupling.
 
-An example module can be found `here <https://github.com/EVerest/everest-core/tree/main/modules/Example>`_.
+Modules in EVerest can be everything like hardware drivers, protocols, authentication logic and more. Build up your development scenario as needed and enhance it by adding your own additional modules.
 
-Interfaces
-----------
+Another way to look at EVerest is its layer architecture:
 
-WIP
+.. image:: img/quick-start-high-level-2.png
 
+Depending on your project use case, you can define the suitable module stack and configure module connections and module parameters.
 
+What modules EVerest already delivers as ready-to-use implementations and which features they currently ship will be explained in detail in the modules documentation.
+
+*****************
+Tools And Helpers
+*****************
+
+Additionally, you have some tools and helpers that work with the framework which makes your EVerest developer's life easier:
+
+.. image:: img/quick-start-high-level-3.png
+
+To understand the benefit delivered by those tools, let's have a sneak preview:
+
+- **Admin Panel**: Tool to show all modules connections and dependencies including the parameters set for the modules.
+- **EVerest Dependency Manager** (edm): Tool that helps you getting all needed repositories from Git for your specific setup.
+- **ev-cli**: Generates module and interface scaffolds based on templates. This way you can start implementing new modules very fast.
+- **MQTT Explorer**: Great for debugging the messages sent between your modules during development phase.
+- **NodeRed** for simulating your EVerest setup
+- **SteVe**: Just in case you want to test your EVerest instance with some OCPP backend functionality: SteVe is an external tool that lets you do exactly that.
+
+How to setup and use those tools will be shown later.
+
+*************************************
+System Requirements and Prerequisites
+*************************************
+
+What is needed to run EVerest?
+
+Hardware
+========
+It is recommended to have at least 4GB of RAM available to build EVerest. More CPU cores will optionally boost the build process, while requiring more RAM accordingly.
+
+We have setup EVerest successfully on Raspberry Pi 4.
+
+Operating System
+================
+EVerest has been tested with Ubuntu, OpenSUSE and Fedora 36. In general, it can be expected to run on most Linux-based systems.
+
+Libraries And Tools
+===================
+
+To create your development environment with all needed tools, libraries and compilers, the section "Prepare Your Environment" in our `Quick Start Guide <./quick_start_guide.html>`_ will walk you through the setup phase.
+
+That guide will also give you a first overview how modules look like and how to get a first simulation running.
+
+That's your next step: `Quick Start Guide <./quick_start_guide.html>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,27 +3,42 @@
 .. image:: img/everest_horizontal-color.svg
     :align: right
 
-EVerest
-==================
-*Current status of Q1 2022*
 
-The primary goal of EVerest is to develop and maintain an open source software stack for EV charging infrastructure.
+*This documentation was last updated in December 2022.*
 
-EVerest is developed having modularity and customizability in mind, so it consists of a framework to configure several interchangeable modules, which are coupled by MQTT with each other.
+***************
+What Is EVerest
+***************
+EVerest is an open source modular framework for setting up a full stack environment for EV charging.
 
-EVerest will help to speed the adoption to e-mobility by utilizing all the open source advantages for the EV charging world. It will also enable new features for local energy management, PV-integration, and many more.
+The modular software architecture fosters customizability and lets you configure your dedicated charging scenarios based on interchangeable modules. All this is glued together by MQTT.
 
-The EVerest project was initiated by PIONIX GmbH to help with the electrification of the mobility sector.
+EVerest will help to speed the adoption to e-mobility by utilizing all the open source advantages for the EV charging world. It will also enable new features for local energy management, PV-integration and many more.
 
-For questions and support please join the `EVerest mailing list <https://lists.lfenergy.org/g/everest>`_.
-There is also a calendar for monthly dev calls.
+The EVerest project was initiated by PIONIX GmbH to help with the electrification of the mobility sector and is an official project of the Linux Foundation Energy.
+
+**************************
+Find Your Way Into EVerest
+**************************
+We prepared a path to get step by step into the EVerest world. It will lead you from a high level overview right into understanding how to implement modules for your dedicated hardware scenarios or developer use cases.
+
+To walk this path, simple go on reading and follow the table of contents below.
+
+Besides that, you might want to reach out and stay in touch with us via the following channels:
+
+* `EVerest mailing list <https://lists.lfenergy.org/g/everest>`_: You will get your questions answered and will also get regular information about our public meetups to which you are invited to join. A tech meetup for all contributors is currently held once a week.
+* `YouTube-Channel <https://www.youtube.com/@lfe_everest>`_: Stay up-to-date with webinars and get insights from the Technical Steering Committee recordings.
+* Don't forget to follow us on `Twitter <https://twitter.com/everestincharge>`_ or `Mastodon <https://fosstodon.org/@EVerest>`_
+
+But now let's dive in the EVerest journey to get you on board. Start on top level with the first chapter and walk the path down to your first module implementation.
 
 .. toctree::
     :numbered:
     :maxdepth: 2
     :glob:
 
-    general/*
+    general/framework
+    general/quick_start_guide
     dev_tools/index
     tutorials/index
     misc/*


### PR DESCRIPTION
The front page of the documentation now gives a short intro about EVerest and guides interested contributors to the communication channels.

The quick start guide now contains less detailed information about basic setup - details are moved to a separate page to keep it clean.

Module concept has been re-structured and the module connection config got enhanced.