### PR TITLE
Minor changes and typos in documentation

### DIFF
--- a/docs/dev_tools/edm.rst
+++ b/docs/dev_tools/edm.rst
@@ -1,10 +1,11 @@
 .. doc_tutorial_EDM
 
 ***
-EDM
+edm
 ***
 
-So far this is the edm - the Everest Dependency Manager which helps you orchestrating the dependencies between the different everest repositories.
+So far, this is the edm - the Everest dependency manager. edm helps you
+orchestrating the dependencies between the different EVerest repositories.
 
 .. contents::
 	:local:
@@ -16,9 +17,11 @@ Dependency Manager for EVerest
 Install and Quick Start
 ***********************
 
-To install the **edm** dependency manager for EVerest you have to perform the following steps.
+To install the dependency manager for EVerest you have to perform the following
+steps.
 
-Please make sure you are running a sufficiently recent version of **Python3 (>=3.6)** and that you are able to install Python packages from source. Usually you just have to ensure that you have **pip**, **setuptools** and **wheel** available. Refer to the `Python Installing Packages <https://packaging.python.org/tutorials/installing-packages/#requirements-for-installing-packages>`_ documentation for indepth guidance if any problems arise.
+Please make sure you are running a sufficiently recent version of **Python3 (>=3.6)** and that you are able to install Python packages from source.
+Usually, you just have to ensure that you have **pip**, **setuptools** and **wheel** available. Refer to the `Python Installing Packages <https://packaging.python.org/tutorials/installing-packages/#requirements-for-installing-packages>`_ documentation for indepth guidance if any problems arise.
 
 .. code-block:: bash
 
@@ -27,7 +30,7 @@ Please make sure you are running a sufficiently recent version of **Python3 (>=3
 Installing edm
 **************
 
-Now you can clone this repository and install **edm**: 
+Now you can clone this repository and install **edm**:
 (make sure you have `set up your ssh key in github <https://www.atlassian.com/git/tutorials/git-ssh>`_ first!)
 
 A script for the steps below can be found `here <https://github.com/EVerest/everest-utils/tree/main/everest-cpp>`_.
@@ -39,7 +42,7 @@ A script for the steps below can be found `here <https://github.com/EVerest/ever
 	python3 -m pip install .
 	edm --register-cmake-module --config ../everest-complete.yaml --workspace ~/checkout/everest-workspace
 
-The last command registers the :ref:`EDM CMake module <cmake_integration_setup>` and creates a workspace in the *~/checkout/everest-workspace* directory from a `config that is shipped with this repository <https://github.com/EVerest/everest-dev-environment/blob/main/everest-complete.yaml>`_. The workspace will have the following structure containing all current dependencies for everest:
+The last command registers the :ref:`edm CMake module <cmake_integration_setup>` and creates a workspace in the *~/checkout/everest-workspace* directory from a `config that is shipped with this repository <https://github.com/EVerest/everest-dev-environment/blob/main/everest-complete.yaml>`_. The workspace will have the following structure containing all current dependencies for EVerest:
 
 .. code-block:: bash
 
@@ -58,22 +61,24 @@ The last command registers the :ref:`EDM CMake module <cmake_integration_setup>`
 	├── RISE-V2G
 	└── workspace-config.yamleverest-core
 
-The workspace-config.yaml contains a copy of the config that was used to create this workspace.
+The workspace-config.yaml contains a copy of the config that was used to create
+this workspace.
 
 Enabling CPM_SOURCE_CACHE
 *************************
-The **edm** dependency manager uses `CPM <https://github.com/cpm-cmake/CPM.cmake>`_ 
-for its CMake integration. This means you *can* and **should** set the 
-*CPM_SOURCE_CACHE* environment variable. This makes sure that dependencies 
-that you do not manage in the workspace are not re-downloaded multiple times. 
-For detailed information and other useful environment variables please 
+The EVerest dependency manager uses
+`CPM <https://github.com/cpm-cmake/CPM.cmake>`_
+for its CMake integration. This means you *can* and **should** set the
+*CPM_SOURCE_CACHE* environment variable. This makes sure that dependencies
+that you do not manage in the workspace are not re-downloaded multiple times.
+For detailed information and other useful environment variables please
 refer to the `CPM Documentation <https://github.com/cpm-cmake/CPM.cmake/blob/master/README.md#CPM_SOURCE_CACHE>`_.
 
 .. code-block:: bash
 
 	export CPM_SOURCE_CACHE=$HOME/.cache/CPM
 
-Building everest
+Building EVerest
 ****************
 Make sure you have installed `ev_cli <ev_cli.html>`_ first.
 You can now use the following commands to build everest-core:
@@ -88,7 +93,8 @@ You can now use the following commands to build everest-core:
 
 Python packages needed to run edm
 *********************************
-The following Python3 packages are needed to run the **edm** dependency manager. If you installed edm using the guide above they were already installed automatically.
+The following Python3 packages are needed to run the EVerest dependency
+manager. If you installed edm using the guide above they were already installed automatically.
 
 + Python >= 3.6
 + Jinja2 >= 3.0
@@ -98,17 +104,24 @@ The following Python3 packages are needed to run the **edm** dependency manager.
 
 Setting up CMake integration
 ############################
-To use the EDM CMake module you must register it in the CMake package registry. You can use the following command to achieve this:
+To use the edm CMake module you must register it in the CMake package registry.
+You can use the following command to achieve this:
 
 .. code-block:: bash
 
 	edm --register-cmake-module
 
-This will create a file at ~/.cmake/packages/EDM/edm that points to the directory in which the EDM CMake module has been installed. You probably have to do this only once after the initial installation, but be advised that this might have to be done again if you reinstall edm with a different version of Python.
+This will create a file at ~/.cmake/packages/EDM/edm that points to the
+directory in which the edm CMake module has been installed. You probably have
+to do this only once after the initial installation, but be advised that this
+might have to be done again if you reinstall edm with a different version of
+Python.
 
 Setting up a workspace
 ######################
-A sample workspace config, everest-complete.yaml, for the EVerest project is provided in the root directory of this repository. You can set up this workspace with the following command.
+A sample workspace config, everest-complete.yaml, for the EVerest project is
+provided in the root directory of this repository. You can set up this
+workspace with the following command.
 
 .. code-block:: bash
 
@@ -116,36 +129,47 @@ A sample workspace config, everest-complete.yaml, for the EVerest project is pro
 
 Updating a workspace
 ####################
-To update a workspace you can edit the workspace-config.yaml file in the root of the workspace. You can then use the following command to apply these changes.
+To update a workspace you can edit the workspace-config.yaml file in the root
+of the workspace. You can then use the following command to apply these
+changes.
 
 .. code-block:: bash
 
 	edm --workspace ~/checkout/everest-workspace --update
 
-If you are currently in the everest-workspace directory the following command has the same effect.
+If you are currently in the everest-workspace directory the following command
+has the same effect.
 
 .. code-block:: bash
 
 	edm --update
 
-Be advised that even if you remove a repository from the config file it WILL NOT be deleted from the workspace.
+Be advised that even if you remove a repository from the config file it WILL
+NOT be deleted from the workspace.
 
-An attempt will be made to switch branches to the ones specified in the config, however this will be aborted if the repository is dirty.
+An attempt will be made to switch branches to the ones specified in the config,
+however this will be aborted if the repository is dirty.
 
-Repositories also WILL NOT be pulled, you should check the state of your repositories afterwards with the commands described in :ref:`Git information at a glance <git_information_at_a_glance>`
+Repositories also WILL NOT be pulled. You should check the state of your
+repositories afterwards with the commands described in
+:ref:`Git information at a glance <git_information_at_a_glance>`
 
-Using the EDM CMake module and dependencies.yaml
+Using the edm CMake module and dependencies.yaml
 ################################################
 
-To use edm from CMake you have to add the following line to the top-level CMakeLists.txt file in the respective source repository:
+To use edm from CMake you have to add the following line to the top-level
+CMakeLists.txt file in the respective source repository:
 
 .. code-block:: bash
 
 	find_package(EDM REQUIRED)
 
-The EDM CMake module will be discovered automatically if you registered the CMake module in the way it described in the Setting up CMake integration section of this readme.
+The edm CMake module will be discovered automatically if you registered the
+CMake module in the way described in the setting up CMake integration
+section of this readme.
 
-To define dependencies you can now add a dependencies.yaml file to your source repository. It should look like this:
+To define dependencies, you can now add a dependencies.yaml file to your source
+repository. It should look like this:
 
 .. code-block:: bash
 
@@ -159,7 +183,8 @@ To define dependencies you can now add a dependencies.yaml file to your source r
 	  git_tag: main
 	  options: ["BUILD_EXAMPLES OFF"]
 
-If you want to automatically check out certain dependencies into a workspace you can add a **workspace.yaml** file to the root of your source repository. It should look like this:
+If you want to automatically check out certain dependencies into a workspace,
+you can add a **workspace.yaml** file to the root of your source repository. It should look like this:
 
 .. code-block:: bash
 
@@ -169,7 +194,8 @@ If you want to automatically check out certain dependencies into a workspace you
 	  liblog:
 	  libtimer:
 
-You can overwrite the git_tag in your workspace.yaml, so you can use a development version in your workspace:
+You can overwrite the git_tag in your workspace.yaml, so you can use a
+development version in your workspace:
 
 .. code-block:: bash
 
@@ -182,27 +208,31 @@ You can overwrite the git_tag in your workspace.yaml, so you can use a developme
 
 Create a workspace config from an existing directory tree
 #########################################################
-Suppose you already have a directory tree that you want to save into a config file. You can do this with the following command:
+Suppose you already have a directory tree that you want to save into a config
+file. You can do this with the following command:
 
 .. code-block:: bash
 
 	edm --create-config custom-config.yaml
 
-This is a short form of
+This is a short form of:
 
 .. code-block:: bash
 
 	edm --create-config custom-config.yaml --include-remotes git@github.com:EVerest/*
 
-and only includes repositories from the EVerest namespace. You can add as many remotes to this list as you want.
+That only includes repositories from the EVerest namespace. You can add as many
+remotes to this list as you want.
 
-For example if you only want to include certain repositories you can use the following command.
+For example, if you only want to include certain repositories, you can use the
+following command:
 
 .. code-block:: bash
 
 	edm --create-config custom-config.yaml --include-remotes git@github.com:EVerest/everest* git@github.com:EVerest/liblog.git
 
-If you want to include all repositories, including external dependencies, in the config you can use the following command.
+If you want to include all repositories, including external dependencies, in
+the config you can use the following command:
 
 .. code-block:: bash
 
@@ -212,19 +242,21 @@ If you want to include all repositories, including external dependencies, in the
 
 Git information at a glance
 ###########################
-You can get a list of all git repositories in the current directory and their state using the following command.
+You can get a list of all git repositories in the current directory and their
+state using the following command:
 
 .. code-block:: bash
 
 	edm --git-info --git-fetch
 
-If you want to know the state of all repositories in a workspace you can use the following command.
+If you want to know the state of all repositories in a workspace you can use
+the following command:
 
 .. code-block:: bash
 
 	edm --workspace ~/checkout/everest-workspace --git-info --git-fetch
 
-This creates output that is similar to the following example.
+This creates output that is similar to the following example:
 
 .. code-block:: bash
 

--- a/docs/dev_tools/ev_cli.rst
+++ b/docs/dev_tools/ev_cli.rst
@@ -25,7 +25,7 @@ It has the following subcommands
   manifest definitions
 
 - interface:
-  auto generation of c++ header files for defined interfaces
+  auto generation of C++ header files for defined interfaces
 
 - helpers:
   utility commands
@@ -48,10 +48,10 @@ common:
   definitions (default: ``../everest-framework``)
 
 - `--clang-format-file`:
-  if c++output should be formatted, set this to the path of the
+  if C++ output should be formatted, set this to the path of the
   .clang-format file
 
-Generating c++ header files for defined interfaces
+Generating C++ header files for defined interfaces
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Assuming that the interface definitions in json format are located at
@@ -69,7 +69,7 @@ header file will be generated.  The former represents the `implementers`
 view, and the latter the `users` view of the interface, when used in a
 module.
 
-Creating and updating auto generated files for modules (c++ only)
+Creating and updating auto generated files for modules (C++ only)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Assuming the modules are located at ``./modules`` and the initial
@@ -183,9 +183,9 @@ subcommands:
    would recreate the ``CMakeLists.txt`` and the
    ``main/SampleInterfaceImpl.cpp`` files, whereas::
 
-    ev-clie module update Example --only module.hpp
+    ev-cli module update Example --only module.hpp
 
-   would update only the module header file ``Example.hpp``
+   would update only the module header file ``Example.hpp``.
 
 
 Auto generating NodeJS modules

--- a/docs/general/02_quick_start_guide.rst
+++ b/docs/general/02_quick_start_guide.rst
@@ -210,7 +210,7 @@ The name of the module is the one given as directory name.
 
 You will see that you get cpp and hpp files for your main module class and also for the interfaces to be implemented.
 
-You main cpp file will have to special functions:
+Your main cpp file will have two special functions:
 
 .. code-block:: c++
 


### PR DESCRIPTION
Yvonne thankfully reviewed some pages in the documentation. Based on that I did some typo fixes and harmonizations, mostly of this here:

- Harmonized the written short representation of EVerest dependency manager to lowercase.
- Harmonized the writing of the uppercase letters EV in EVerest everywhere except the lowercase writing of the Git repos (e.g. everest-core)
- Some interpunctuation changes.
- Max line length of 80
