### PR TITLE
Change to global link refs

### DIFF
--- a/docs/dev_tools/edm.rst
+++ b/docs/dev_tools/edm.rst
@@ -75,7 +75,7 @@ refer to the `CPM Documentation <https://github.com/cpm-cmake/CPM.cmake/blob/mas
 
 Building everest
 ****************
-Make sure you have installed `ev_cli <ev_cli.html>`_ first.
+Make sure you have installed :ref:`ev_cli <evcli doc>` first.
 You can now use the following commands to build everest-core:
 
 .. code-block:: bash

--- a/docs/dev_tools/edm.rst
+++ b/docs/dev_tools/edm.rst
@@ -75,7 +75,7 @@ refer to the `CPM Documentation <https://github.com/cpm-cmake/CPM.cmake/blob/mas
 
 Building everest
 ****************
-Make sure you have installed :ref:`ev_cli <evcli doc>` first.
+Make sure you have installed :ref:`ev_cli <evcli_main>` first.
 You can now use the following commands to build everest-core:
 
 .. code-block:: bash

--- a/docs/dev_tools/ev_cli.rst
+++ b/docs/dev_tools/ev_cli.rst
@@ -1,5 +1,7 @@
 .. doc_EV-CLI
 
+.. _evcli doc:
+
 ======
 ev-cli
 ======

--- a/docs/dev_tools/ev_cli.rst
+++ b/docs/dev_tools/ev_cli.rst
@@ -1,6 +1,6 @@
 .. doc_EV-CLI
 
-.. _evcli doc:
+.. _evcli_main:
 
 ======
 ev-cli

--- a/docs/general/01_framework.rst
+++ b/docs/general/01_framework.rst
@@ -64,8 +64,8 @@ EVerest has been tested with Ubuntu, OpenSUSE and Fedora 36. In general, it can 
 Libraries And Tools
 ===================
 
-To create your development environment with all needed tools, libraries and compilers, the section "Prepare Your Environment" in our `Quick Start Guide <./02_quick_start_guide.html>`_ will walk you through the setup phase.
+To create your development environment with all needed tools, libraries and compilers, the section "Prepare Your Environment" in our :ref:`Quick Start Guide <Quick Start Guide>` will walk you through the setup phase.
 
 That guide will also give you a first overview how modules look like and how to get a first simulation running.
 
-That's your next step: `Quick Start Guide <./02_quick_start_guide.html>`_
+That's your next step: :ref:`Quick Start Guide <Quick Start Guide>`

--- a/docs/general/01_framework.rst
+++ b/docs/general/01_framework.rst
@@ -64,8 +64,12 @@ EVerest has been tested with Ubuntu, OpenSUSE and Fedora 36. In general, it can 
 Libraries And Tools
 ===================
 
-To create your development environment with all needed tools, libraries and compilers, the section "Prepare Your Environment" in our :ref:`Quick Start Guide <Quick Start Guide>` will walk you through the setup phase.
+To create your development environment with all needed tools, libraries and
+compilers, the section "Prepare Your Environment" in our
+:ref:`Quick Start Guide <quickstartguide_main>` will walk you through the setup
+phase.
 
-That guide will also give you a first overview how modules look like and how to get a first simulation running.
+That guide will also give you a first overview how modules look like and how to
+get a first simulation running.
 
-That's your next step: :ref:`Quick Start Guide <Quick Start Guide>`
+That's your next step: :ref:`Quick Start Guide <quickstartguide_main>`

--- a/docs/general/02_quick_start_guide.rst
+++ b/docs/general/02_quick_start_guide.rst
@@ -1,5 +1,7 @@
 .. quick_start:
 
+.. _Quick Start Guide:
+
 ################################################
 A Real Quick Guide To EVerest
 ################################################
@@ -10,9 +12,11 @@ Prepare Your Development Environment
 
 Needed Packages
 ===============
-You will need Python, Jinja2, PyYAML, a compiler and some more system libraries set up. See the detailed page for `setting up your development environment <03_detail_pre_setup.html>`_ to see some examples for operating systems.
+You will need Python, Jinja2, PyYAML, a compiler and some more system libraries set up. See the detailed page for :ref:`setting up your development environment <Prepare Dev Environment>` to see some examples for operating systems.
 
 After having created your environment, return back here, where we will go on with downloading and installing EVerest.
+
+.. _Quick Start Download and Install:
 
 ********************
 Download And Install
@@ -95,6 +99,8 @@ If you get an error during the build process stating that ev-cli is installed in
 Simulating EVerest
 ******************
 
+.. _Quick Start Prepare Helpers:
+
 Prepare The Helpers
 ===================
 EVerest comes with prepared Docker containers, which are needed for simulation and further development. To get this working, make sure you have Docker and Docker-Compose installed during the previous install phase. (If not, see install instructions for `Docker <https://docs.docker.com/engine/install/#server>`_ and `Docker-Compose <https://docs.docker.com/compose/install/#install-compose)>`_!)
@@ -137,7 +143,7 @@ That makes us ready for entering the simulation phase described in the next chap
 Software in a loop
 ==================
 
-Make sure you have prepared the helpers necessary for simulating EVerest as shown in the `previous section <02_quick_start_guide.html#prepare-the-helpers>`_.
+Make sure you have prepared the helpers necessary for simulating EVerest as shown in the :ref:`previous section <Quick Start Prepare Helpers>`.
 
 After having done that, change to the directory /everest-core/build/, which has been created during EVerest install.
 
@@ -176,6 +182,8 @@ You will have to install and run it via npm. After that, you can reach the Admin
 
 A detailed walk-through to assist you with that is in preparation.
 
+.. _Quick Start Module Setup:
+
 ************
 Module Setup
 ************
@@ -186,7 +194,7 @@ What parts does a module in EVerest consist of?
 - Types definition
 - Module implementation
 
-Get a more detailed insight into the module config and implementation files on the `EVerest Module Concept page <04_detail_module_concept.html>`_.
+Get a more detailed insight into the module config and implementation files on the :ref:`EVerest Module Concept page <Module Concept>`.
 
 Here, we want to go on with setting up a module template to use that as a base for our own implementation.
 

--- a/docs/general/02_quick_start_guide.rst
+++ b/docs/general/02_quick_start_guide.rst
@@ -1,6 +1,6 @@
 .. quick_start:
 
-.. _Quick Start Guide:
+.. _quickstartguide_main:
 
 ################################################
 A Real Quick Guide To EVerest
@@ -12,11 +12,15 @@ Prepare Your Development Environment
 
 Needed Packages
 ===============
-You will need Python, Jinja2, PyYAML, a compiler and some more system libraries set up. See the detailed page for :ref:`setting up your development environment <Prepare Dev Environment>` to see some examples for operating systems.
+You will need Python, Jinja2, PyYAML, a compiler and some more system libraries
+set up. See the detailed page for
+:ref:`setting up your development environment <preparedevenv_main>` to see some
+examples for operating systems.
 
-After having created your environment, return back here, where we will go on with downloading and installing EVerest.
+After having created your environment, return back here, where we will go on
+with downloading and installing EVerest.
 
-.. _Quick Start Download and Install:
+.. _quickstartguide_download_install:
 
 ********************
 Download And Install
@@ -99,7 +103,7 @@ If you get an error during the build process stating that ev-cli is installed in
 Simulating EVerest
 ******************
 
-.. _Quick Start Prepare Helpers:
+.. _quickstartguide_helpers:
 
 Prepare The Helpers
 ===================
@@ -143,9 +147,11 @@ That makes us ready for entering the simulation phase described in the next chap
 Software in a loop
 ==================
 
-Make sure you have prepared the helpers necessary for simulating EVerest as shown in the :ref:`previous section <Quick Start Prepare Helpers>`.
+Make sure you have prepared the helpers necessary for simulating EVerest as
+shown in the :ref:`previous section <quickstartguide_helpers>`.
 
-After having done that, change to the directory /everest-core/build/, which has been created during EVerest install.
+After having done that, change to the directory /everest-core/build/, which has
+been created during EVerest install.
 
 We will startup EVerest now with a software-in-a-loop (SIL) config.
 
@@ -182,7 +188,7 @@ You will have to install and run it via npm. After that, you can reach the Admin
 
 A detailed walk-through to assist you with that is in preparation.
 
-.. _Quick Start Module Setup:
+.. _quickstartguide_modulesetup:
 
 ************
 Module Setup
@@ -194,9 +200,11 @@ What parts does a module in EVerest consist of?
 - Types definition
 - Module implementation
 
-Get a more detailed insight into the module config and implementation files on the :ref:`EVerest Module Concept page <Module Concept>`.
+Get a more detailed insight into the module config and implementation files on
+the :ref:`EVerest Module Concept page <moduleconcept_main>`.
 
-Here, we want to go on with setting up a module template to use that as a base for our own implementation.
+Here, we want to go on with setting up a module template to use that as a base
+for our own implementation.
 
 *************************
 Implementing a New Module

--- a/docs/general/03_detail_pre_setup.rst
+++ b/docs/general/03_detail_pre_setup.rst
@@ -1,5 +1,7 @@
 .. detail_pre_setup:
 
+.. _Prepare Dev Environment:
+
 ####################################
 Prepare Your Development Environment
 ####################################
@@ -47,4 +49,4 @@ Tested with Fedora 36. Here is how to get your needed libraries with `dnf`.
   sudo dnf update
   sudo dnf install make automake gcc gcc-c++ kernel-devel python3-pip git rsync wget cmake doxygen graphviz clang-tools-extra cppcheck maven java-11-openjdk java-11-openjdk-devel boost-devel nodejs nodejs-devel npm openssl-devel libsqlite3x-devel curl rfkill libpcap-devel
 
-Now, it's time to continue with the `Quick Start Guide to install EVerest <02_quick_start_guide.html#download-and-install>`_.
+Now, it's time to continue with the :ref:`Quick Start Guide to install EVerest <Quick Start Download and Install>`.

--- a/docs/general/03_detail_pre_setup.rst
+++ b/docs/general/03_detail_pre_setup.rst
@@ -1,6 +1,6 @@
 .. detail_pre_setup:
 
-.. _Prepare Dev Environment:
+.. _preparedevenv_main:
 
 ####################################
 Prepare Your Development Environment
@@ -49,4 +49,5 @@ Tested with Fedora 36. Here is how to get your needed libraries with `dnf`.
   sudo dnf update
   sudo dnf install make automake gcc gcc-c++ kernel-devel python3-pip git rsync wget cmake doxygen graphviz clang-tools-extra cppcheck maven java-11-openjdk java-11-openjdk-devel boost-devel nodejs nodejs-devel npm openssl-devel libsqlite3x-devel curl rfkill libpcap-devel
 
-Now, it's time to continue with the :ref:`Quick Start Guide to install EVerest <Quick Start Download and Install>`.
+Now, it's time to continue with the
+:ref:`Quick Start Guide to install EVerest <quickstartguide_download_install>`.

--- a/docs/general/04_detail_module_concept.rst
+++ b/docs/general/04_detail_module_concept.rst
@@ -1,5 +1,7 @@
 .. detail_module_concept:
 
+.. _Module Concept:
+
 ######################
 EVerest Module Concept
 ######################
@@ -151,4 +153,4 @@ You can find some examples of module connection definitions in the `everest-core
 Where To Go Next
 ================
 
-If you came here via the Quick Start Guide, here is your way back to action: `Quick Start Guide to setup a module <02_quick_start_guide.html#module-setup>`_.
+If you came here via the Quick Start Guide, here is your way back to action: :ref:`Quick Start Guide to setup a module <Quick Start Module Setup>`.

--- a/docs/general/04_detail_module_concept.rst
+++ b/docs/general/04_detail_module_concept.rst
@@ -1,6 +1,6 @@
 .. detail_module_concept:
 
-.. _Module Concept:
+.. _moduleconcept_main:
 
 ######################
 EVerest Module Concept
@@ -153,4 +153,5 @@ You can find some examples of module connection definitions in the `everest-core
 Where To Go Next
 ================
 
-If you came here via the Quick Start Guide, here is your way back to action: :ref:`Quick Start Guide to setup a module <Quick Start Module Setup>`.
+If you came here via the Quick Start Guide, here is your way back to action:
+:ref:`Quick Start Guide to setup a module <quickstartguide_modulesetup>`.

--- a/docs/hardware/pionix_belay_box.rst
+++ b/docs/hardware/pionix_belay_box.rst
@@ -265,7 +265,7 @@ For deployment on real products you should consider using Yocto or similar
 instead.
 
 For further information like the partitioning scheme and updating Raspbian,
-section `BelayBox Further Information`_ .
+section :ref:`BelayBox Further Information <BelayBox Further Info>`.
 
 EVerest
 =======
@@ -372,6 +372,8 @@ custom installation and still use the online updates for the base system.
 
 If you do it for the first time, reboot BelayBox so that
 ``everest-dev.service`` is used from now-on instead of ``everest.service``.
+
+.. _BelayBox Further Info:
 
 BelayBox Further Information
 ****************************

--- a/docs/hardware/pionix_belay_box.rst
+++ b/docs/hardware/pionix_belay_box.rst
@@ -265,7 +265,7 @@ For deployment on real products you should consider using Yocto or similar
 instead.
 
 For further information like the partitioning scheme and updating Raspbian,
-section :ref:`BelayBox Further Information <BelayBox Further Info>`.
+section :ref:`BelayBox Further Information <belaybox_furtherinfo>`.
 
 EVerest
 =======
@@ -373,7 +373,7 @@ custom installation and still use the online updates for the base system.
 If you do it for the first time, reboot BelayBox so that
 ``everest-dev.service`` is used from now-on instead of ``everest.service``.
 
-.. _BelayBox Further Info:
+.. _belaybox_furtherinfo:
 
 BelayBox Further Information
 ****************************


### PR DESCRIPTION
Changed the documentation links to global targets/references where not done yet. Goal: No dead links when changing the page structure of the documentation.