### PR TITLE
remove `.vscode/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # General
+.vscode
 .DS_Store
 .AppleDouble
 .LSOverride

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "restructuredtext.confPath": "${workspaceFolder}/docs"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "esbonio.sphinx.confDir": "${workspaceFolder}/docs"
+}


### PR DESCRIPTION
It's common to not include IDE-specific config to keep the repository IDE-agnostic. Seems to be common sense in all EVerest-repos ([only `connector-serverless` contains a `.vscode/`, still](https://github.com/search?q=org%3AEVerest+path%3A%2F%5E.vscode%5C%2F%2F&type=code)).