### PR TITLE
Docs: git commands use HTTPS instead SSH

### DIFF
--- a/docs/dev_tools/edm.rst
+++ b/docs/dev_tools/edm.rst
@@ -42,7 +42,7 @@ A script for the steps below can be found `here <https://github.com/EVerest/ever
 
 .. code-block:: bash
 
-  git clone git@github.com:EVerest/everest-dev-environment.git
+  git clone https://github.com/EVerest/everest-dev-environment
   cd everest-dev-environment/dependency_manager
   python3 -m pip install .
   edm init --workspace ~/checkout/everest-workspace
@@ -157,11 +157,11 @@ repository. It should look like this:
 
 	---
 	liblog:
-	  git: git@github.com:EVerest/liblog.git
+	  git: https://github.com/EVerest/liblog
 	  git_tag: main
 	  options: ["BUILD_EXAMPLES OFF"]
 	libtimer:
-	  git: git@github.com:EVerest/libtimer.git
+	  git: https://github.com/EVerest/libtimer
 	  git_tag: main
 	  options: ["BUILD_EXAMPLES OFF"]
 
@@ -178,7 +178,7 @@ This is a short form of:
 
 .. code-block:: bash
 
-  edm --create-config custom-config.yaml --include-remotes git@github.com:EVerest/*
+  edm --create-config custom-config.yaml --include-remotes https://github.com/EVerest/*
 
 and only includes repositories from the EVerest namespace. You can add as many
 remotes to this list as you want.
@@ -188,7 +188,7 @@ following command.
 
 .. code-block:: bash
 
-  edm --create-config custom-config.yaml --include-remotes git@github.com:EVerest/everest* git@github.com:EVerest/liblog.git
+  edm --create-config custom-config.yaml --include-remotes https://github.com/EVerest/everest* https://github.com/EVerest/liblog.git
 
 If you want to include all repositories, including external dependencies, in
 the config you can use the following command:

--- a/docs/dev_tools/edm.rst
+++ b/docs/dev_tools/edm.rst
@@ -36,7 +36,6 @@ Installing edm
 **************
 
 Now you can clone this repository and install **edm**:
-(make sure you have `set up your ssh key in github <https://www.atlassian.com/git/tutorials/git-ssh>`_ first!)
 
 A script for the steps below can be found `here <https://github.com/EVerest/everest-utils/tree/main/everest-cpp>`_.
 

--- a/docs/general/02_detail_pre_setup.rst
+++ b/docs/general/02_detail_pre_setup.rst
@@ -37,14 +37,6 @@ which are needed for the EVerest dependency manager:
 
   python3 -m pip install --upgrade pip setuptools wheel
 
-Encryption Setup for GitHub
-===========================
-
-To get the repositories from GitHub to your local development environment,
-please
-`set your SSH key in GitHub <https://www.atlassian.com/git/tutorials/git-ssh>`_
-.
-
 A complete list of libraries to be installed is given by the following best
 practices which setup a development environment on a number of operating
 systems.

--- a/docs/general/03_quick_start_guide.rst
+++ b/docs/general/03_quick_start_guide.rst
@@ -49,7 +49,7 @@ HOME directory:
 
 .. code-block:: bash
 
-  git clone git@github.com:EVerest/everest-dev-environment.git
+  git clone https://github.com/EVerest/everest-dev-environment
   cd everest-dev-environment/dependency_manager
   python3 -m pip install .
 

--- a/docs/tutorials/how_to_git/index.rst
+++ b/docs/tutorials/how_to_git/index.rst
@@ -140,7 +140,7 @@ you can do the following:
   /main_repo$ git checkout -b wip/new_stuff develop
   /main_repo$ # do some work, add and commit
   /main_repo$ # add private repo as additional remote, called 'private'
-  /main_repo$ git remote add private git@github.com:PrivateUser/PrivateRepo.git
+  /main_repo$ git remote add private https://github.com/PrivateUser/PrivateRepo
   /main_repo$ git push private
 
 Now, the branch ``wip/new_stuff`` will be pushed to your private


### PR DESCRIPTION
All EVerest repos are public, i.e. there's no authentication needed. So SSH-keys are just not needed.

For the Git-tutorial, newer ways to authenticate and securely store the credentials locally could be mentioned. See https://github.com/hickford/git-credential-oauth (and [it's comparison to Microsoft's resp. GitHub's GCM](https://github.com/hickford/git-credential-oauth#comparison-with-git-credential-manager)).

See also this [good answer on StackOverflow](https://stackoverflow.com/questions/11041729/git-clone-with-https-or-ssh-remote/76078371#76078371) on the question "git clone with HTTPS or SSH?".