### PR TITLE
docs(quick-start): remove duplicate requirements.txt install

### DIFF
--- a/docs/general/03_quick_start_guide.rst
+++ b/docs/general/03_quick_start_guide.rst
@@ -125,8 +125,6 @@ certificates:
 
 .. code-block:: bash
 
-  cd {EVerest Workspace Directory}/Josev
-  python3 -m pip install -r requirements.txt
   cd {EVerest Workspace Directory}/Josev/iso15118/shared/pki
   ./create_certs.sh -v iso-2 -i {EVerest Workspace Directory}/everest-core
 


### PR DESCRIPTION
We only need this once and this way seems to be keep with the original intent the most.