### PR TITLE
Added working groups incl chair persons

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -5,6 +5,7 @@ There are a few ways to connect with the EVerest project:
 *   [EVerest mailing list](https://lists.lfenergy.org/g/everest)
 *   [EVerest Technical Steering Committee mailing list / Sensitive Topics](https://lists.lfenergy.org/g/everest-tsc)
 *   [EVerest channel on LF Energy Zulip](https://lfenergy.zulipchat.com/)
+*   [EVerest Working Groups](https://everest.github.io/nightly/#weekly-tech-meetup-and-working-groups)
 *   [Issue tracker](https://github.com/EVerest/EVerest/issues)
 
 ## How to ask for help

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -57,7 +57,7 @@ be resolved by voting. The voting process is a simple majority in which each com
 
 This project, just like all of open source, is a global community. In addition to the [Code of Conduct], this project will:
 
-* Keep all communucation on open channels ( mailing list, forums, chat ).
+* Keep all communication on open channels ( mailing list, forums, chat ).
 * Be respectful of time and language differences between community members ( such as scheduling meetings, email/issue responsiveness, etc ).
 * Ensure tools are able to be used by community members regardless of their region.
 

--- a/tsc/MEMBERS.md
+++ b/tsc/MEMBERS.md
@@ -16,7 +16,7 @@ format of working groups. The working groups with their chair persons and the
 technical leads are:
 
 - General Working Group
--- Chair: Janek Metzner
+-- Chair: Janek Metzner ([@janekmelectric](https://github.com/janekmelectric))
 
 - Car Communication WG
 -- Chair: Tim Valbert
@@ -24,6 +24,7 @@ technical leads are:
 
 - Cloud Communication WG
 -- Chair: Robert de Leeuw
+-- Tech Lead: Piet Gömpel ([@Pietfried](https://github.com/pietfried))
 
 - EVerest Framework & Tools WG
 -- Chair: Manuel Ziegler ([@Krealyt](https://github.com/krealyt))
@@ -31,6 +32,9 @@ technical leads are:
 
 - Testing & CI WG
 -- Chair: Benjamin Mosler
+-- Tech Leads: Andreas Heinrich and Kai-Uwe Hermann
+   ([@andistorm](https://github.com/andistorm) and
+   [@hikinggrass](https://github.com/hikinggrass))
 
 More details about the working groups and how to get there, see:
 [EVerest Working Groups](https://everest.github.io/nightly/#weekly-tech-meetup-and-working-groups)

--- a/tsc/MEMBERS.md
+++ b/tsc/MEMBERS.md
@@ -9,3 +9,28 @@ Commitee Members:
 - Moritz Barsnick [Chargebyte] ([@barsnick](https://github.com/barsnick))
 - Holger Rapp [qwello] ([@SirVer](https://github.com/SirVer))
 - K. Shankari [Joint office of Energy and Transportation] ([@shankari](https://github.com/shankari))
+
+
+Regular exchange about the ongoing open source development is done in the
+format of working groups. The working groups with their chair persons and the
+technical leads are:
+
+- General Working Group
+-- Chair: Janek Metzner
+
+- Car Communication WG
+-- Chair: Tim Valbert
+-- Tech Lead: Sebastian Lukas ([@SebaLukas](https://github.com/SebaLukas))
+
+- Cloud Communication WG
+-- Chair: Robert de Leeuw
+
+- EVerest Framework & Tools WG
+-- Chair: Manuel Ziegler ([@Krealyt](https://github.com/krealyt))
+-- Tech Lead: Kai-Uwe Hermann ([@hikinggrass](https://github.com/hikinggrass))
+
+- Testing & CI WG
+-- Chair: Benjamin Mosler
+
+More details about the working groups and how to get there, see:
+[EVerest Working Groups](https://everest.github.io/nightly/#weekly-tech-meetup-and-working-groups)


### PR DESCRIPTION
Added info about working groups and chair persons incl tech leads to the official governance docs. Also a link to the "EVerest compass" with info about links to the meetings and further community channels.

Will still add the missing tech leads.