### PR TITLE
doc: added recomended build instructions to quickstart

### DIFF
--- a/docs/general/03_quick_start_guide.rst
+++ b/docs/general/03_quick_start_guide.rst
@@ -91,6 +91,10 @@ directory. In the above example, it is located at
 More details about edm, see the dedicated
 :ref:`edm page in this documentation <edm_main>`.
 
+
+However if you want everest to pull its own dependencies (which is recommended), remove all folders in `{EVerest Workspace Directory}` except for everest-core, everest-dev-environment, everest-utils and Josev (as you will need these later on).
+Doing this ensures that during the compilation of everest-core all dependencies are downloaded automatically
+
 EVerest Command Line Interface: ``ev-cli``
 ----------------------------------------
 


### PR DESCRIPTION
compiling everest-core by deleting most dependencies downloaded by edm --init was recommended to me @lukas-mertens and fixed compilation errors so i added a section in the quick start docs