### PR TITLE
Fix broken link to OCPP 2.0.1 implementations's status

### DIFF
--- a/docs/tutorials/how_to_ocpp201/index.rst
+++ b/docs/tutorials/how_to_ocpp201/index.rst
@@ -9,7 +9,7 @@ How To: OCPP 2.0.1 in EVerest
   see `the GitHub repository of libocpp <https://github.com/EVerest/libocpp>`_.
 
 The OCPP 2.0.1 implementation in EVerest is currently under development.
-You can check `this document <https://github.com/EVerest/libocpp/blob/main/doc/ocpp_201_status.md>`_
+You can check `this document <https://github.com/EVerest/libocpp/blob/main/doc/v201/ocpp_201_status.md>`_
 for the current status.
 
 This is a tutorial about how to set up and configure OCPP 2.0.1 in EVerest.


### PR DESCRIPTION
In 15 Nov 2024, libocpp's commit 74f82e3 changed the dictory structure,
from doc/ocpp_201_status.md => to doc/v201/ocpp_201_status.md,
breaking the original link.