### PR TITLE
doc: update install instructions

### DIFF
--- a/docs/general/02_detail_pre_setup.rst
+++ b/docs/general/02_detail_pre_setup.rst
@@ -95,7 +95,7 @@ Use `apt` to get your needed libraries installed:
 .. code-block:: bash
 
   sudo apt update
-  sudo apt install -y python3-pip git rsync wget cmake doxygen graphviz build-essential clang-tidy cppcheck openjdk-17-jdk npm docker docker-compose libboost-all-dev nodejs libssl-dev libsqlite3-dev clang-format curl rfkill libpcap-dev libevent-dev pkg-config libcap-dev
+  sudo apt install -y python3-pip git rsync wget cmake doxygen graphviz build-essential clang-tidy cppcheck openjdk-17-jdk npm docker.io docker-compose libboost-all-dev nodejs libssl-dev libsqlite3-dev clang-format curl rfkill libpcap-dev libevent-dev pkg-config libcap-dev
 
 Please make sure to have `nodejs` installed with minimum version 10.20 for `node_api` version 6+. For updating to a supported version, please follow the install procedure here: `<https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions>`_.
 

--- a/docs/general/02_detail_pre_setup.rst
+++ b/docs/general/02_detail_pre_setup.rst
@@ -97,8 +97,6 @@ Use `apt` to get your needed libraries installed:
   sudo apt update
   sudo apt install -y python3-pip git rsync wget cmake doxygen graphviz build-essential clang-tidy cppcheck openjdk-17-jdk npm docker.io docker-compose libboost-all-dev nodejs libssl-dev libsqlite3-dev clang-format curl rfkill libpcap-dev libevent-dev pkg-config libcap-dev
 
-Please make sure to have `nodejs` installed with minimum version 10.20 for `node_api` version 6+. For updating to a supported version, please follow the install procedure here: `<https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions>`_.
-
 OpenSUSE
 --------
 Use `zypper` to get your needed libraries installed:


### PR DESCRIPTION
The `docker` package has been a transitional package since Ubuntu 20. It was dropped from Ubuntu 24, and thus the package install command will fail there. You need to install the package named `docker.io` (also for Ubuntu 22).

The `nodejs` note is outdated for Ubuntu, the correct version is available via `apt`.