### PR TITLE
doc: correct Java dependencies

### DIFF
--- a/docs/general/02_detail_pre_setup.rst
+++ b/docs/general/02_detail_pre_setup.rst
@@ -136,10 +136,9 @@ of your choice.
 
 Java dependency
 ---------------
-Java is not required for running the core of EVerest. However, it is required
-if you want to install certificates for ISO 15118 communication as currently
-the Java Keytool is used. Also the EXI (Efficient XML Interchange) part of
-Josev requires Java.
+Java is not required for running the core of EVerest. However, it is
+required if you want to run the PyEvJosev EV simulation, as the EXI
+(Efficient XML Interchange) part of Josev requires Java.
 
 Python versions with pyenv
 --------------------------

--- a/docs/general/03_quick_start_guide.rst
+++ b/docs/general/03_quick_start_guide.rst
@@ -126,39 +126,6 @@ HOME directory in `.local/bin/`.
 
 In a later step, we will use ``ev-cli`` to create module stubs.
 
-Packages for ISO 15118 communication
-------------------------------------
-
-To be able to build EVerest with ISO 15118 capability, you will have to
-install the requirements for Josev:
-
-.. code-block:: bash
-
-  cd {EVerest Workspace Directory}/Josev
-  python3 -m pip install -r requirements.txt
-
-For ISO 15118 communication including Plug&Charge, install Josev and some CA
-certificates:
-
-.. code-block:: bash
-
-  cd {EVerest Workspace Directory}/Josev/iso15118/shared/pki
-  ./create_certs.sh -v iso-2 -i {EVerest Workspace Directory}/everest-core
-
-This will enable ISO 15118 communication including Plug&Charge and install the
-required CA certificates inside `config/certs/ca` and the client certificates,
-private keys and password files inside `config/certs/client`.
-
-.. attention::
-
-  This will generate an example PKI setup that can only be used for testing
-  and simulation. It will not work and is not recommended for production.
-
-  As the shell script uses the Java `keytool`, it is required for this
-  procedure to have Java installed.
-
-The script for setting up PKI can also be used with the EvseV2G module.
-
 Build EVerest
 =============
 


### PR DESCRIPTION
Java is now only required for EV simulation.

Caveats regarding the TLS/PKI certificates (now created via CMake, without Java) should be mentioned elsewhere.