### PR TITLE
Add note on mosquitto Docker startup failure

### DIFF
--- a/docs/general/03_quick_start_guide.rst
+++ b/docs/general/03_quick_start_guide.rst
@@ -213,6 +213,24 @@ other containers in the network.
 
 .. note::
 
+  If the Mosquitto Docker container fails to start with an error similar to:
+
+  .. code-block:: bash
+
+    docker run --name mqtt-server --network infranet_network -p 1883:1883 -p 9001:9001 ghcr.io/everest/everest-dev-environment/mosquitto:docker-images-v0.1.0
+    mosquitto version 2.0.10 starting
+    Config loaded from /mosquitto/config/mosquitto.conf.
+    Opening ipv4 listen socket on port 1883.
+    Opening ipv6 listen socket on port 1883.
+    Opening websockets listen socket on port 9001.
+    Error: Unable to create websockets listener on port 9001.
+
+  The root cause might be the lack of file descriptor limit in your Docker configuration.
+  To resolve this, you may need to set the ``nofile`` limit for Docker.
+  For instructions, see `this guide <https://ichbinblau.github.io/2019/09/06/Setup-nofile-for-Docker/>`_.
+
+.. note::
+
   The docker container can be controlled with docker compose as well:
 
   .. code-block:: bash


### PR DESCRIPTION
This change adds a note about a possible root cause of mosquitto container startup failures.
The new note points to a guide on how to fix this problem: https://ichbinblau.github.io/2019/09/06/Setup-nofile-for-Docker. This note can save time for future readers facing the same issue.

The problem was observed on Fedora 42 and Docker 28.3.3. The root cause was lack of file descriptor limit, which led to the following mosquitto error:
```
docker run --name mqtt-server --network infranet_network -p 1883:1883 -p 9001:9001 ghcr.io/everest/everest-dev-environment/mosquitto:docker-images-v0.1.0
1758397856: mosquitto version 2.0.10 starting
1758397856: mosquitto version 2.0.10 starting
1758397856: Config loaded from /mosquitto/config/mosquitto.conf.
1758397856: Config loaded from /mosquitto/config/mosquitto.conf.
1758397856: Opening ipv4 listen socket on port 1883.
1758397856: Opening ipv4 listen socket on port 1883.
1758397856: Opening ipv6 listen socket on port 1883.
1758397856: Opening ipv6 listen socket on port 1883.
1758397856: Opening websockets listen socket on port 9001.
1758397856: Opening websockets listen socket on port 9001.
1758397856: libuv support not compiled in
1758397856: libuv support not compiled in
1758397856: OOM allocating 1073741816 fds
1758397856: OOM allocating 1073741816 fds
1758397856: ZERO RANDOM FD
1758397856: ZERO RANDOM FD
1758397856: Error: Unable to create websockets listener on port 9001.
1758397856: Error: Unable to create websockets listener on port 9001.
```

Closes #266 