### PR TITLE
Typo fix: IEC 6185 -> IEC 61851

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ management, PV-integration and many more!
 
 # Main Features
 
-- IEC 6185
+- IEC 61851
 - DIN SPEC 70121
 - ISO 15118: -2 and -20
 - SAE J1772


### PR DESCRIPTION
I couldn't find an IEC 6185 (especially not related to EV charging), so I assume the README has a typo and wanted to declare IEC 61851 (Electric vehicle conductive charging system) as the supported standard?